### PR TITLE
Fix potential chain halt (Audit 5.3)

### DIFF
--- a/contracts/rollup/lib/BlockHashLib.sol
+++ b/contracts/rollup/lib/BlockHashLib.sol
@@ -16,8 +16,8 @@ library BlockHashLib {
 	/// @param blockHashes The memory array of block hashes
 	/// @return The current block number
 	function getBlockNumber(
-		bytes32[] memory blockHashes
-	) internal pure returns (uint32) {
+		bytes32[] storage blockHashes
+	) internal view returns (uint32) {
 		return uint32(blockHashes.length);
 	}
 
@@ -25,8 +25,8 @@ library BlockHashLib {
 	/// @param blockHashes The memory array of block hashes
 	/// @return The hash of the previous block
 	function getPrevHash(
-		bytes32[] memory blockHashes
-	) internal pure returns (bytes32) {
+		bytes32[] storage blockHashes
+	) internal view returns (bytes32) {
 		return blockHashes[blockHashes.length - 1];
 	}
 


### PR DESCRIPTION
- Changed `getPrevHash` function parameter from `memory` to `storage` to avoid unnecessary array copying
- Similarly updated `getBlockNumber` function to use `storage` instead of `memory`