### PR TITLE
Ignored return value

### DIFF
--- a/contracts/test/withdrawal/Withdrawal2Test.sol
+++ b/contracts/test/withdrawal/Withdrawal2Test.sol
@@ -7,4 +7,8 @@ contract Withdrawal2Test is Withdrawal {
 	function getVal() external pure returns (uint256) {
 		return 3;
 	}
+
+	function addOwner(address _owner) external {
+		_transferOwnership(_owner);
+	}
 }

--- a/contracts/withdrawal/Withdrawal.sol
+++ b/contracts/withdrawal/Withdrawal.sol
@@ -66,7 +66,12 @@ contract Withdrawal is IWithdrawal, UUPSUpgradeable, OwnableUpgradeable {
 		contribution = IContribution(_contribution);
 		liquidity = _liquidity;
 		for (uint256 i = 0; i < _directWithdrawalTokenIndices.length; i++) {
-			directWithdrawalTokenIndices.add(_directWithdrawalTokenIndices[i]);
+			bool result = directWithdrawalTokenIndices.add(
+				_directWithdrawalTokenIndices[i]
+			);
+			if (result == false) {
+				revert TokenAlreadyExist(_directWithdrawalTokenIndices[i]);
+			}
 		}
 	}
 

--- a/test/withdrawal/withdrawal.test.ts
+++ b/test/withdrawal/withdrawal.test.ts
@@ -191,6 +191,28 @@ describe('Withdrawal', () => {
 					),
 				).to.be.revertedWithCustomError(withdrawalFactory, 'AddressZero')
 			})
+
+			it('token index is already exist', async () => {
+				const withdrawalFactory =
+					await ethers.getContractFactory('Withdrawal2Test')
+				const withdrawal = await withdrawalFactory.deploy()
+				const { deployer } = await getSigners()
+				const tmpAddress = ethers.Wallet.createRandom().address
+				await withdrawal.addOwner(deployer.address)
+				await withdrawal.addDirectWithdrawalTokenIndices([1])
+				await expect(
+					withdrawal.initialize(
+						tmpAddress,
+						tmpAddress,
+						tmpAddress,
+						tmpAddress,
+						tmpAddress,
+						[1],
+					),
+				)
+					.to.be.revertedWithCustomError(withdrawalFactory, 'TokenAlreadyExist')
+					.withArgs(1)
+			})
 		})
 	})
 	describe('submitWithdrawalProof', () => {


### PR DESCRIPTION
```
In Withdrawal.initialize() the return value of directWithdrawalTokenIndices.add() is
ignored. In case _directWithdrawalTokenIndices contains twice the same value, the execution will not revert as it would for addDirectWithdrawalTokenIndices().

```