### PR TITLE
Fix: Prevent DOS in withdrawals batch (Audit 5.4)

### DIFF
--- a/contracts/liquidity/Liquidity.sol
+++ b/contracts/liquidity/Liquidity.sol
@@ -359,7 +359,7 @@ contract Liquidity is
 	) internal {
 		TokenInfo memory tokenInfo = getTokenInfo(withdrawal_.tokenIndex);
 
-		bool result;
+		bool result = true;
 		if (tokenInfo.tokenType == TokenType.NATIVE) {
 			bool success = payable(withdrawal_.recipient).send(
 				withdrawal_.amount

--- a/contracts/liquidity/Liquidity.sol
+++ b/contracts/liquidity/Liquidity.sol
@@ -352,16 +352,7 @@ contract Liquidity is
 		WithdrawalLib.Withdrawal[] calldata withdrawals
 	) private {
 		for (uint256 i = 0; i < withdrawals.length; i++) {
-			TokenInfo memory tokenInfo = getTokenInfo(
-				withdrawals[i].tokenIndex
-			);
-			_sendToken(
-				tokenInfo.tokenType,
-				tokenInfo.tokenAddress,
-				withdrawals[i].recipient,
-				withdrawals[i].amount,
-				tokenInfo.tokenId
-			);
+			_processDirectWithdrawal(withdrawals[i]);
 		}
 		if (withdrawals.length > 0) {
 			emit DirectWithdrawalsProcessed(_lastProcessedDirectWithdrawalId);

--- a/contracts/liquidity/Liquidity.sol
+++ b/contracts/liquidity/Liquidity.sol
@@ -385,6 +385,7 @@ contract Liquidity is
 
 		bool result = true;
 		if (tokenInfo.tokenType == TokenType.NATIVE) {
+			// solhint-disable-next-line check-send-result
 			bool success = payable(withdrawal_.recipient).send(
 				withdrawal_.amount
 			);
@@ -425,6 +426,7 @@ contract Liquidity is
 		}
 		if (!result) {
 			bytes32 withdrawalHash = withdrawal_.getHash();
+			// solhint-disable-next-line reentrancy
 			claimableWithdrawals[withdrawalHash] = block.timestamp;
 			emit DirectWithdrawalFailed(withdrawalHash, withdrawal_);
 			emit WithdrawalClaimable(withdrawalHash);


### PR DESCRIPTION
- Refactor _processDirectWithdrawals to handle individual failures
- Implement non-reverting withdrawal logic for each token type
- Add DirectWithdrawalFailed event and make failed withdrawals claimable