### PR TITLE
7.5 Implementations can be initialized

### DIFF
--- a/contracts/block-builder-registry/BlockBuilderRegistry.sol
+++ b/contracts/block-builder-registry/BlockBuilderRegistry.sol
@@ -34,6 +34,10 @@ contract BlockBuilderRegistry is
 		_;
 	}
 
+	constructor() {
+		_disableInitializers();
+	}
+
 	/**
 	 * @notice Initialize the contract.
 	 * @param _rollup The address of the rollup contract.

--- a/contracts/contribution/Contribution.sol
+++ b/contracts/contribution/Contribution.sol
@@ -37,6 +37,10 @@ contract Contribution is
 	/// @dev period => array of tags
 	mapping(uint256 => bytes32[]) private allTags;
 
+	constructor() {
+		_disableInitializers();
+	}
+
 	function initialize() external initializer {
 		__UUPSUpgradeable_init();
 		__AccessControl_init();

--- a/contracts/liquidity/Liquidity.sol
+++ b/contracts/liquidity/Liquidity.sol
@@ -81,6 +81,10 @@ contract Liquidity is
 		_;
 	}
 
+	constructor() {
+		_disableInitializers();
+	}
+
 	function initialize(
 		address _l1ScrollMessenger,
 		address _rollup,

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -48,6 +48,10 @@ contract Rollup is IRollup, OwnableUpgradeable, UUPSUpgradeable {
 		_;
 	}
 
+	constructor() {
+		_disableInitializers();
+	}
+
 	function initialize(
 		address _scrollMessenger,
 		address _liquidity,

--- a/contracts/withdrawal/Withdrawal.sol
+++ b/contracts/withdrawal/Withdrawal.sol
@@ -35,6 +35,10 @@ contract Withdrawal is IWithdrawal, UUPSUpgradeable, OwnableUpgradeable {
 	uint256 public lastDirectWithdrawalId;
 	uint256 public lastClaimableWithdrawalId;
 
+	constructor() {
+		_disableInitializers();
+	}
+
 	function initialize(
 		address _scrollMessenger,
 		address _withdrawalVerifier,

--- a/test/block-builder-registry/block-builder-registry.test.ts
+++ b/test/block-builder-registry/block-builder-registry.test.ts
@@ -43,7 +43,7 @@ describe('BlockBuilderRegistry', () => {
 		const blockBuilderRegistry = (await upgrades.deployProxy(
 			blockBuilderRegistryFactory,
 			[await rollup.getAddress(), await verifier.getAddress()],
-			{ kind: 'uups' },
+			{ kind: 'uups', unsafeAllow: ['constructor'] },
 		)) as unknown as BlockBuilderRegistry
 		return [blockBuilderRegistry, rollup, verifier]
 	}
@@ -191,7 +191,7 @@ describe('BlockBuilderRegistry', () => {
 					upgrades.deployProxy(
 						blockBuilderRegistryFactory,
 						[ethers.ZeroAddress, tmpAddress],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(
 					blockBuilderRegistryFactory,
@@ -207,7 +207,7 @@ describe('BlockBuilderRegistry', () => {
 					upgrades.deployProxy(
 						blockBuilderRegistryFactory,
 						[tmpAddress, ethers.ZeroAddress],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(
 					blockBuilderRegistryFactory,
@@ -1030,6 +1030,7 @@ describe('BlockBuilderRegistry', () => {
 			const next = await upgrades.upgradeProxy(
 				await blockBuilderRegistry.getAddress(),
 				registry2Factory,
+				{ unsafeAllow: ['constructor'] },
 			)
 			const blockBuilderInfo = await blockBuilderRegistry.blockBuilders(
 				signers.blockBuilder1.address,
@@ -1049,6 +1050,7 @@ describe('BlockBuilderRegistry', () => {
 				upgrades.upgradeProxy(
 					await blockBuilderRegistry.getAddress(),
 					registryFactory,
+					{ unsafeAllow: ['constructor'] },
 				),
 			)
 				.to.be.revertedWithCustomError(

--- a/test/contribution/contribution.test.ts
+++ b/test/contribution/contribution.test.ts
@@ -9,6 +9,7 @@ describe('Contribution', function () {
 		const contributionFactory = await ethers.getContractFactory('Contribution')
 		const contribution = (await upgrades.deployProxy(contributionFactory, [], {
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Contribution
 
 		// register the weight of the contribution
@@ -275,6 +276,7 @@ describe('Contribution', function () {
 			const next = await upgrades.upgradeProxy(
 				await contribution.getAddress(),
 				contribution2Factory,
+				{ unsafeAllow: ['constructor'] },
 			)
 			const currentPeriod = await next.currentPeriod()
 			expect(currentPeriod).to.equal(1)
@@ -293,6 +295,7 @@ describe('Contribution', function () {
 				upgrades.upgradeProxy(
 					await contribution.getAddress(),
 					contribution2Factory,
+					{ unsafeAllow: ['constructor'] },
 				),
 			)
 				.to.be.revertedWithCustomError(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -47,10 +47,12 @@ describe('Integration', function () {
 		const contributionFactory = await ethers.getContractFactory('Contribution')
 		l1Contribution = (await upgrades.deployProxy(contributionFactory, [], {
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Contribution
 
 		l2Contribution = (await upgrades.deployProxy(contributionFactory, [], {
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Contribution
 
 		// scroll messanger deployment
@@ -77,11 +79,13 @@ describe('Integration', function () {
 		rollup = (await upgrades.deployProxy(rollupFactory, [], {
 			initializer: false,
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Rollup
 		const withdrawalFactory = await ethers.getContractFactory('Withdrawal')
 		withdrawal = (await upgrades.deployProxy(withdrawalFactory, [], {
 			initializer: false,
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Withdrawal
 		const registryFactory = await ethers.getContractFactory(
 			'BlockBuilderRegistry',
@@ -89,6 +93,7 @@ describe('Integration', function () {
 		registry = (await upgrades.deployProxy(registryFactory, [], {
 			initializer: false,
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as BlockBuilderRegistry
 
 		// L1 deployment. Initialize later.
@@ -96,6 +101,7 @@ describe('Integration', function () {
 		liquidity = (await upgrades.deployProxy(liquidityFactory, [], {
 			initializer: false,
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Liquidity
 
 		// get address

--- a/test/liquidity/lib/deposit-queue-lib.test.ts
+++ b/test/liquidity/lib/deposit-queue-lib.test.ts
@@ -114,8 +114,8 @@ describe('DepositQueueLib', function () {
 			it('should revert when trying to analyze non-existent deposits', async function () {
 				const lib = await loadFixture(setup)
 				await expect(lib.analyze(1, []))
-					.to.be.revertedWithCustomError(lib, 'TriedAnalyzeNotExists')
-					.withArgs(1, 0)
+					.to.be.revertedWithCustomError(lib, 'TriedAnalyzeOutOfRange')
+					.withArgs(1, 1, 0)
 			})
 
 			it('should revert when trying to reject out of range deposits', async function () {

--- a/test/liquidity/liquidity.test.ts
+++ b/test/liquidity/liquidity.test.ts
@@ -44,7 +44,7 @@ describe('Liquidity', () => {
 				await contribution.getAddress(),
 				INITIAL_ERC20_TOKEN_ADDRESSES,
 			],
-			{ kind: 'uups' },
+			{ kind: 'uups', unsafeAllow: ['constructor'] },
 		)) as unknown as Liquidity
 		await l1ScrollMessenger.setLiquidity(await liquidity.getAddress())
 		return {
@@ -112,7 +112,7 @@ describe('Liquidity', () => {
 							tmpAddress,
 							INITIAL_ERC20_TOKEN_ADDRESSES,
 						],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(liquidityFactory, 'AddressZero')
 			})
@@ -130,7 +130,7 @@ describe('Liquidity', () => {
 							tmpAddress,
 							INITIAL_ERC20_TOKEN_ADDRESSES,
 						],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(liquidityFactory, 'AddressZero')
 			})
@@ -148,7 +148,7 @@ describe('Liquidity', () => {
 							tmpAddress,
 							INITIAL_ERC20_TOKEN_ADDRESSES,
 						],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(liquidityFactory, 'AddressZero')
 			})
@@ -166,7 +166,7 @@ describe('Liquidity', () => {
 							tmpAddress,
 							INITIAL_ERC20_TOKEN_ADDRESSES,
 						],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(liquidityFactory, 'AddressZero')
 			})
@@ -184,7 +184,7 @@ describe('Liquidity', () => {
 							ethers.ZeroAddress,
 							INITIAL_ERC20_TOKEN_ADDRESSES,
 						],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(liquidityFactory, 'AddressZero')
 			})
@@ -2064,6 +2064,7 @@ describe('Liquidity', () => {
 			const next = await upgrades.upgradeProxy(
 				await liquidity.getAddress(),
 				liquidity2Factory,
+				{ unsafeAllow: ['constructor'] },
 			)
 			const beforeRole = await liquidity.ANALYZER()
 
@@ -2081,7 +2082,9 @@ describe('Liquidity', () => {
 			)
 			const role = await liquidity.DEFAULT_ADMIN_ROLE()
 			await expect(
-				upgrades.upgradeProxy(await liquidity.getAddress(), liquidity2Factory),
+				upgrades.upgradeProxy(await liquidity.getAddress(), liquidity2Factory, {
+					unsafeAllow: ['constructor'],
+				}),
 			)
 				.to.be.revertedWithCustomError(
 					liquidity,

--- a/test/rollup.test.ts
+++ b/test/rollup.test.ts
@@ -27,17 +27,20 @@ describe('Rollup', function () {
 		registry = (await upgrades.deployProxy(registryFactory, [], {
 			initializer: false,
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as BlockBuilderRegistry
 
 		const rollupFactory = await ethers.getContractFactory('Rollup')
 		rollup = (await upgrades.deployProxy(rollupFactory, [], {
 			initializer: false,
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Rollup
 
 		const contributionFactory = await ethers.getContractFactory('Contribution')
 		const contribution = (await upgrades.deployProxy(contributionFactory, [], {
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Contribution
 		liquidityAddress = ethers.Wallet.createRandom().address
 		await rollup.initialize(

--- a/test/rollup/rollup.test.ts
+++ b/test/rollup/rollup.test.ts
@@ -48,7 +48,7 @@ describe('Rollup', () => {
 				await blockBuilderRegistry.getAddress(),
 				await contribution.getAddress(),
 			],
-			{ kind: 'uups' },
+			{ kind: 'uups', unsafeAllow: ['constructor'] },
 		)) as unknown as Rollup
 		return [rollup, blockBuilderRegistry, l2ScrollMessenger, contribution]
 	}
@@ -162,7 +162,7 @@ describe('Rollup', () => {
 					upgrades.deployProxy(
 						rollupFactory,
 						[ethers.ZeroAddress, tmpAddress, tmpAddress, tmpAddress],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(rollupFactory, 'AddressZero')
 			})
@@ -174,7 +174,7 @@ describe('Rollup', () => {
 					upgrades.deployProxy(
 						rollupFactory,
 						[tmpAddress, ethers.ZeroAddress, tmpAddress, tmpAddress],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(rollupFactory, 'AddressZero')
 			})
@@ -186,7 +186,7 @@ describe('Rollup', () => {
 					upgrades.deployProxy(
 						rollupFactory,
 						[tmpAddress, tmpAddress, ethers.ZeroAddress, tmpAddress],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(rollupFactory, 'AddressZero')
 			})
@@ -198,7 +198,7 @@ describe('Rollup', () => {
 					upgrades.deployProxy(
 						rollupFactory,
 						[tmpAddress, tmpAddress, tmpAddress, ethers.ZeroAddress],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(rollupFactory, 'AddressZero')
 			})
@@ -788,6 +788,7 @@ describe('Rollup', () => {
 			const next = await upgrades.upgradeProxy(
 				await rollup.getAddress(),
 				rollup2Factory,
+				{ unsafeAllow: ['constructor'] },
 			)
 			const hash = await rollup.blockHashes(0)
 			expect(hash).to.equal(FIRST_BLOCK_HASH)
@@ -802,7 +803,9 @@ describe('Rollup', () => {
 				signers.user1,
 			)
 			await expect(
-				upgrades.upgradeProxy(await rollup.getAddress(), rollupFactory),
+				upgrades.upgradeProxy(await rollup.getAddress(), rollupFactory, {
+					unsafeAllow: ['constructor'],
+				}),
 			)
 				.to.be.revertedWithCustomError(rollup, 'OwnableUnauthorizedAccount')
 				.withArgs(signers.user1.address)

--- a/test/withdrawal.test.ts
+++ b/test/withdrawal.test.ts
@@ -17,17 +17,20 @@ describe('Withdrawal', function () {
 		registry = (await upgrades.deployProxy(registryFactory, [], {
 			initializer: false,
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as BlockBuilderRegistry
 
 		const contributionFactory = await ethers.getContractFactory('Contribution')
 		const contribution = (await upgrades.deployProxy(contributionFactory, [], {
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Contribution
 
 		const rollupFactory = await ethers.getContractFactory('Rollup')
 		rollup = (await upgrades.deployProxy(rollupFactory, [], {
 			initializer: false,
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Rollup
 		await rollup.initialize(
 			ethers.Wallet.createRandom().address,
@@ -53,6 +56,7 @@ describe('Withdrawal', function () {
 		withdrawal = (await upgrades.deployProxy(withdrawalFactory, [], {
 			initializer: false,
 			kind: 'uups',
+			unsafeAllow: ['constructor'],
 		})) as unknown as Withdrawal
 
 		await withdrawal.initialize(

--- a/test/withdrawal/withdrawal.test.ts
+++ b/test/withdrawal/withdrawal.test.ts
@@ -56,7 +56,7 @@ describe('Withdrawal', () => {
 				await contribution.getAddress(),
 				DIRECT_WITHDRAWAL_TOKEN_INDICES,
 			],
-			{ kind: 'uups' },
+			{ kind: 'uups', unsafeAllow: ['constructor'] },
 		)) as unknown as Withdrawal
 		return [
 			withdrawal,
@@ -115,7 +115,7 @@ describe('Withdrawal', () => {
 							tmpAddress,
 							DIRECT_WITHDRAWAL_TOKEN_INDICES,
 						],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(withdrawalFactory, 'AddressZero')
 			})
@@ -133,7 +133,7 @@ describe('Withdrawal', () => {
 							tmpAddress,
 							DIRECT_WITHDRAWAL_TOKEN_INDICES,
 						],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(withdrawalFactory, 'AddressZero')
 			})
@@ -151,7 +151,7 @@ describe('Withdrawal', () => {
 							tmpAddress,
 							DIRECT_WITHDRAWAL_TOKEN_INDICES,
 						],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(withdrawalFactory, 'AddressZero')
 			})
@@ -169,7 +169,7 @@ describe('Withdrawal', () => {
 							tmpAddress,
 							DIRECT_WITHDRAWAL_TOKEN_INDICES,
 						],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(withdrawalFactory, 'AddressZero')
 			})
@@ -187,7 +187,7 @@ describe('Withdrawal', () => {
 							ethers.ZeroAddress,
 							DIRECT_WITHDRAWAL_TOKEN_INDICES,
 						],
-						{ kind: 'uups' },
+						{ kind: 'uups', unsafeAllow: ['constructor'] },
 					),
 				).to.be.revertedWithCustomError(withdrawalFactory, 'AddressZero')
 			})
@@ -789,6 +789,7 @@ describe('Withdrawal', () => {
 			const next = await upgrades.upgradeProxy(
 				await withdrawal.getAddress(),
 				withdrawal2Factory,
+				{ unsafeAllow: ['constructor'] },
 			)
 			const owner = await withdrawal.owner()
 			expect(owner).to.equal(deployer.address)
@@ -806,6 +807,7 @@ describe('Withdrawal', () => {
 				upgrades.upgradeProxy(
 					await withdrawal.getAddress(),
 					withdrawal2Factory,
+					{ unsafeAllow: ['constructor'] },
 				),
 			)
 				.to.be.revertedWithCustomError(withdrawal, 'OwnableUnauthorizedAccount')


### PR DESCRIPTION
```
Every contract in the codebase are UUPSUpgradeable. However, _disableInitializers() is never called in their constructors, this means that the implementations can be initialized by untrusted parties.
In the current state of the code, it does not impose a security issue as no contract contains the SELFDESTRUCT or DELEGATECALL opcodes (except for the UUPSUpgradable contract itself that however protect upgradeToAndCall() behind an onlyProxy modifier to mitigate a vulnerability found in older versions of openzeppelin contracts).
However, it is recommended to call _disableInitializers() in the constructor of the contracts as a best practice and to prevent future issues in case the codebase is updated in the future with the aforementioned opcodes.
```