### PR TITLE
5.7 Bad naming of function

### DIFF
--- a/contracts/block-builder-registry/BlockBuilderInfoLib.sol
+++ b/contracts/block-builder-registry/BlockBuilderInfoLib.sol
@@ -19,7 +19,7 @@ library BlockBuilderInfoLib {
 	/**
 	 * @notice Check if the challenge duration has passed.
 	 */
-	function isChallengeDuration(
+	function hasChallengeDurationPassed(
 		IBlockBuilderRegistry.BlockBuilderInfo memory info
 	) internal view returns (bool) {
 		return block.timestamp - info.stopTime >= CHALLENGE_DURATION;

--- a/contracts/block-builder-registry/BlockBuilderRegistry.sol
+++ b/contracts/block-builder-registry/BlockBuilderRegistry.sol
@@ -89,7 +89,7 @@ contract BlockBuilderRegistry is
 	function unstake() external isStaking {
 		// Check if the last block submission is not within 24 hour.
 		BlockBuilderInfo memory info = blockBuilders[_msgSender()];
-		if (!info.isChallengeDuration()) {
+		if (!info.hasChallengeDurationPassed()) {
 			revert CannotUnstakeWithinChallengeDuration();
 		}
 		string memory url = info.blockBuilderUrl;

--- a/contracts/test/block-builder-registry/BlockBuilderInfoLibTest.sol
+++ b/contracts/test/block-builder-registry/BlockBuilderInfoLibTest.sol
@@ -13,10 +13,10 @@ contract BlockBuilderInfoLibTest {
 		return info.isStaking();
 	}
 
-	function isChallengeDuration(
+	function hasChallengeDurationPassed(
 		IBlockBuilderRegistry.BlockBuilderInfo memory info
 	) external view returns (bool) {
-		return info.isChallengeDuration();
+		return info.hasChallengeDurationPassed();
 	}
 
 	function isStakeAmountSufficient(

--- a/test/block-builder-registry/block-builder-info-lib.test.ts
+++ b/test/block-builder-registry/block-builder-info-lib.test.ts
@@ -41,12 +41,12 @@ describe('BlockBuilderInfoLib', () => {
 			expect(value).to.false
 		})
 	})
-	describe('isChallengeDuration', () => {
+	describe('hasChallengeDurationPassed', () => {
 		it('challenge duration', async () => {
 			const lib = await loadFixture(setup)
 			const currentTimestamp = await time.latest()
 			const stopTime = currentTimestamp - ONE_DAY_SECONDS
-			const value = await lib.isChallengeDuration(
+			const value = await lib.hasChallengeDurationPassed(
 				getDefaultBlockBuilderInfo(0n, stopTime),
 			)
 			expect(value).to.true
@@ -55,7 +55,7 @@ describe('BlockBuilderInfoLib', () => {
 			const lib = await loadFixture(setup)
 			const currentTimestamp = await time.latest()
 			const stopTime = currentTimestamp - ONE_DAY_SECONDS + 1
-			const value = await lib.isChallengeDuration(
+			const value = await lib.hasChallengeDurationPassed(
 				getDefaultBlockBuilderInfo(0n, stopTime),
 			)
 			expect(value).to.false


### PR DESCRIPTION
```
5.7 Bad Naming of Function
isChallengeDuration
Correctness Low Version 1
The function isChallengeDuration()'s name is misleading as it checks that since the stopTime, at
least CHALLENGE_DURATION seconds has passed. Hence, it actually returns true if the challenge duration is over and returns false if still in the challenge duration.

```