### PR TITLE
7.4 Missing Events

### DIFF
--- a/contracts/withdrawal/Withdrawal.sol
+++ b/contracts/withdrawal/Withdrawal.sol
@@ -69,14 +69,7 @@ contract Withdrawal is IWithdrawal, UUPSUpgradeable, OwnableUpgradeable {
 		rollup = IRollup(_rollup);
 		contribution = IContribution(_contribution);
 		liquidity = _liquidity;
-		for (uint256 i = 0; i < _directWithdrawalTokenIndices.length; i++) {
-			bool result = directWithdrawalTokenIndices.add(
-				_directWithdrawalTokenIndices[i]
-			);
-			if (!result) {
-				revert TokenAlreadyExist(_directWithdrawalTokenIndices[i]);
-			}
-		}
+		innerAddDirectWithdrawalTokenIndices(_directWithdrawalTokenIndices);
 	}
 
 	// added onlyOwner for dummy zkp verification
@@ -241,6 +234,12 @@ contract Withdrawal is IWithdrawal, UUPSUpgradeable, OwnableUpgradeable {
 	function addDirectWithdrawalTokenIndices(
 		uint256[] calldata tokenIndices
 	) external onlyOwner {
+		innerAddDirectWithdrawalTokenIndices(tokenIndices);
+	}
+
+	function innerAddDirectWithdrawalTokenIndices(
+		uint256[] memory tokenIndices
+	) private {
 		for (uint256 i = 0; i < tokenIndices.length; i++) {
 			bool result = directWithdrawalTokenIndices.add(tokenIndices[i]);
 			if (!result) {

--- a/test/withdrawal/withdrawal.test.ts
+++ b/test/withdrawal/withdrawal.test.ts
@@ -102,6 +102,15 @@ describe('Withdrawal', () => {
 				const signers = await getSigners()
 				expect(await withdrawal.owner()).to.equal(signers.deployer.address)
 			})
+			it('generate DirectWithdrawalTokenIndicesAdded event', async () => {
+				const [withdrawal] = await loadFixture(setup)
+				const filter = withdrawal.filters.DirectWithdrawalTokenIndicesAdded()
+				const events = await withdrawal.queryFilter(filter)
+				expect(events.length).to.equal(1)
+				expect(events[0].args?.tokenIndices).to.deep.equal(
+					DIRECT_WITHDRAWAL_TOKEN_INDICES,
+				)
+			})
 		})
 		describe('fail', () => {
 			it('should revert when initializing twice', async () => {


### PR DESCRIPTION
```
Code partially corrected
Both Contribution and Withdrawal now emit events when important state changes occur except for
Withdrawal.initialize() that add direct withdrawal token indices but does not emit the
DirectWithdrawalTokenIndicesAdded event.
```
