### PR TITLE
feat: pause block posting

### DIFF
--- a/contracts/rollup/IRollup.sol
+++ b/contracts/rollup/IRollup.sol
@@ -182,6 +182,18 @@ interface IRollup {
 	) external payable;
 
 	/**
+	 * @notice Pauses block posting on the rollup chain
+	 * @dev Can only be called by the contract owner
+	 */
+	function pauseBlockPosting() external;
+
+	/**
+	 * @notice Unpauses block posting on the rollup chain
+	 * @dev Can only be called by the contract owner
+	 */
+	function unpauseBlockPosting() external;
+
+	/**
 	 * @notice Sets the rate limiter constants for the rollup chain
 	 * @dev Can only be called by the contract owner
 	 * @param thresholdInterval The threshold block submission interval in seconds


### PR DESCRIPTION
## Summary
- Add `PausableUpgradeable` to Rollup contract to allow pausing `postRegistrationBlock` / `postNonRegistrationBlock`
- Add `pauseBlockPosting()` / `unpauseBlockPosting()` callable by owner
- Add 7 test cases for pause functionality

## Changes
- `contracts/rollup/Rollup.sol`: Inherit `PausableUpgradeable`, add `whenNotPaused` modifier, add pause/unpause functions
- `contracts/rollup/IRollup.sol`: Add `pauseBlockPosting` / `unpauseBlockPosting` to interface
- `test/rollup/rollup.test.ts`: Add 7 pause-related tests

## Note
- `Claim.getAllocationInfo` test has a pre-existing failure unrelated to this PR

## Test plan
- [x] `npx hardhat compile` passes
- [x] All 7 pause-related tests passing
- [ ] Deploy to Scroll testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)