### PR TITLE
Fix claim allocation info test expectation

### DIFF
--- a/test/claim/claim.test.ts
+++ b/test/claim/claim.test.ts
@@ -14,6 +14,34 @@ import {
 } from '../../typechain-types'
 
 describe('Claim', () => {
+	const GENESIS_TIMESTAMP = 1722999120n
+	const PHASE0_REWARD_PER_DAY = ethers.parseEther('8937500')
+	const NUM_PHASES = 7
+	const PHASE0_PERIOD = 16n
+
+	const calculateExpectedAllocationPerPeriod = (
+		startTimestamp: bigint,
+		periodInterval: bigint,
+		periodNumber: bigint,
+	): bigint => {
+		const SECONDS_IN_A_DAY = 86400n
+		let elapsedDays =
+			(startTimestamp + periodNumber * periodInterval - GENESIS_TIMESTAMP) /
+			SECONDS_IN_A_DAY
+		let rewardPerDay = PHASE0_REWARD_PER_DAY
+
+		for (let i = 0; i < NUM_PHASES; i++) {
+			const phaseDays = PHASE0_PERIOD << BigInt(i)
+			if (elapsedDays < phaseDays) {
+				break
+			}
+			elapsedDays -= phaseDays
+			rewardPerDay /= 2n
+		}
+
+		return (rewardPerDay * periodInterval) / SECONDS_IN_A_DAY
+	}
+
 	type TestObjects = {
 		claim: Claim
 		scrollMessenger: L2ScrollMessengerTestForClaim
@@ -583,8 +611,11 @@ describe('Claim', () => {
 			const { claim } = await loadFixture(setup)
 			const user = ethers.Wallet.createRandom().address
 			const info = await claim.getAllocationInfo(0, user)
+			const constants = await claim.getAllocationConstants()
+			const expectedAllocationPerPeriod =
+				calculateExpectedAllocationPerPeriod(constants[0], constants[1], 0n)
 			expect(info[0]).to.equal(0n)
-			expect(info[1]).to.equal(23274739583333333333333n)
+			expect(info[1]).to.equal(expectedAllocationPerPeriod)
 			expect(info[2]).to.equal(0n)
 			expect(info[3]).to.equal(0n)
 		})


### PR DESCRIPTION
## Summary
- replace the fixed `getAllocationInfo` expectation in `test/claim/claim.test.ts` with a dynamically calculated value
- derive the expected allocation from `getAllocationConstants()` so the test follows the same time-based reward schedule as the contract
- keep the assertion focused on the contract behavior instead of a hard-coded value that becomes stale when the reward phase changes

## Background
The failing test was asserting a fixed `allocationPerPeriod` value for period `0`.

`Claim` initializes `startTimestamp` from the current block timestamp, and `AllocationLib` computes rewards from the elapsed days since `GENESIS_TIMESTAMP`. Because the reward schedule halves across phases, the expected allocation changes over time.

That made the test date-dependent: it passed when the fixed value matched the active reward phase, then started failing once the schedule moved to the next phase. The contract logic itself remained consistent with the allocation schedule.

## Changes
- add a small helper in the claim test that mirrors the allocation-per-period calculation from the reward schedule constants
- fetch allocation constants from the deployed contract in the test
- compare `info[1]` against the derived expected value instead of a stale literal

## Why This Fix
This keeps the test aligned with the contract's intended behavior without changing production logic. The issue was in the test expectation, not in `Claim` or `AllocationLib`.

## Testing
- `npm test`
